### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,13 +75,13 @@ body {margin:0;
 	    
 		<tr>
             <td><a href="#anchorDVRFT">Dual Virtual Radial Fitts' Task (dual-VRFT)</a></td>
-            <td><a href="#anchorDVRFT">Execute and imagine tapping on radially arranged targets while executing simultaneous space bar presses</a></td>
+            <td><a href="#anchorDVRFT">Execute and imagine tapping on radially arranged targets</a></td>
 			<!-- <td></td>-->
         </tr>
 		
 		<tr>
             <td><a href="#anchorFPJT">Final Position Judgement Task (FPJT)</a></td>
-            <td><a href="#anchorFPJT">Imagine a series of auditory instructed movements and judge whether a human figure matches the imagined final position</a></td>
+            <td><a href="#anchorFPJT">Imagine auditory instructed movements and judge whether a human figure matches the imagined final position</a></td>
 			<!-- <td></td>-->
         </tr>
 		
@@ -156,9 +156,9 @@ body {margin:0;
 		
 		<tr>
             <td colspan=3>
-            <p>The Dual Virtual Radial Fitts’ Task (dual-VRFT) is an adaptation of the Virtual Radial Fitts’ Task (VRFT; e.g., Caeyenberghs et al., 2009), based on Fitts’ law (Fitts, 1954). Participants tap between a central circle and five radially arranged targets, with movement difficulty manipulated by varying the target width. In execution trials, participants use a stylus with their dominant hand to tap the central circle and the targets on the screen in a given order. In imagery trials, they imagine executing the same tapping sequence. With their spare hand, participants press the space bar on each executed and imagined tap. The task allows movement times in execution and imagery to be measured in exactly the same way, thereby focusing on movement times of the manipulated movements (i.e., forward movements).</p>
-<p>In the dual-VRFT, Fitts’ law holds in both execution and imagery, with imagery being slower than execution (Czilczer et al., in preparation). The dual-VRFT assesses timing-related movement imagery ability through capturing the degree to which the difficulty of a movement is reflected in imagery.</p>
-<p>The current version (Czilczer et al., in preparation) includes one block each for execution and imagery, with five difficulties presented across trials. A familiarization with tapping targets of varying sizes, a comprehension check, and practice trials precede the main task. The task requires a stylus. While a touchscreen is recommended to ensure a stable tapping surface, it is not strictly required.
+            <p>The Dual Virtual Radial Fitts’ Task (dual-VRFT) is an adaptation of the Virtual Radial Fitts’ Task (VRFT; e.g., Caeyenberghs et al., 2009), based on Fitts’ law (Fitts, 1954). Participants tap and imagine tapping between a central circle and five radially arranged targets in a specified order. Movement difficulty varies across trials by manipulating target width. To ensure identical measurement of movement times in execution and imagery, participants press the space bar with their non-dominant hand for each executed and imagined tap.</p>
+<p>In the dual-VRFT, Fitts’ law applies to both execution and imagery, with imagery being slower than execution (Czilczer et al., in preparation). The dual-VRFT assesses timing-related movement imagery ability by capturing how accurately the difficulty of a movement is reflected in imagery.</p>
+<p>The current version (Czilczer et al., in preparation) includes one block each for execution and imagery, with five difficulties presented across trials. A familiarization with tapping targets of varying sizes, a comprehension check, and practice trials precede the main task. The task requires a stylus with a fine tip. While a touchscreen is recommended to ensure a stable tapping surface, it is not strictly required.
 </p>
             <p></p>
 			</td>
@@ -205,7 +205,7 @@ body {margin:0;
 		
 		<tr>
             <td colspan=3>
-            <p>The Final Position Judgment Task (FPJT) build on previous imagery–stimulus comparison tasks (Madan & Singhal, 2013; Schott, 2013). Participants hear a sequence of auditory movement instructions. Starting from an upright standing position, participants imagine how it feels and looks like to execute these movements. In the FPJT, a single visual stimulus showing a human figure in a specific position is presented after the final auditory instruction. In 50% of trials, the visual stimulus includes one incorrect movement. Unlike earlier imagery–stimulus comparison tasks, requiring a selection among multiple visual stimuli, the FPJT involves a binary judgment: whether the visual stimulus matches the imagined final position. This allows for the measurement of both reaction times and accuracy.</p>
+            <p>The Final Position Judgment Task (FPJT) build on previous imagery–stimulus comparison tasks (Madan & Singhal, 2013; Schott, 2013). Participants hear a sequence of auditory instructed movements. Starting from an upright standing position, participants imagine how it feels and looks like to execute these movements. In the FPJT, a single visual stimulus showing a human figure in a specific position is presented after the final auditory instruction. In 50% of trials, the visual stimulus includes one incorrect movement. Unlike earlier imagery–stimulus comparison tasks, requiring a selection among multiple visual stimuli, the FPJT involves a binary judgment: whether the visual stimulus matches the imagined final position. This allows for the measurement of both response times and accuracy.</p>
 	    <p>The FPJT requires participants to generate and manipulate their imagery based on the auditory instructions, maintain it throughout the sequence of instructions, and inspect their imagery to evaluate it against the visual stimulus. Response times and error rates tend to increase with an increasing number of sequential instructions (Czilczer et al., in preparation).</p>
 <p>Throughout the FPJT (Czilczer et al., in preparation), four to seven auditory instructions are presented per trial, each involving a movement of the head, torso, or a limb (left or right arm or leg). The main task is preceded by a familiarization with auditory and visual stimuli, a comprehension check, and practice trials.
 </p>


### PR DESCRIPTION
removed an error in the FPJT description and shortened the short descriptions for the FPJT and dual-VRFT at the top of the website (so they only need 1 row); shortened the dual-VRFT text